### PR TITLE
Update logReq to return new fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/keycard",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,14 +79,15 @@ export class Keycard {
     const { secret } = this;
     const limit = limits.monthly;
 
+    // Unlimited requests to snapshot APIs (example: if hub is sending requests to hub itself or to score-api)
+    const unlimitedRequests = key === secret;
+
     // If key is not in active keys, it's not valid.
-    if (activeKeys[key] === undefined) return { valid: false };
+    if (!unlimitedRequests && activeKeys[key] === undefined) return { valid: false };
 
     activeKeys[key]++;
     let keyCount = activeKeys[key];
 
-    // Unlimited requests to snapshot APIs (example: if hub is sending requests to hub itself or to score-api)
-    const unlimitedRequests = key === secret;
     if (unlimitedRequests) keyCount = 0;
     // Increase the total count for this key, but don't wait for it to finish.
     if (!unlimitedRequests) this.callAPI('log_req', { key }).catch();

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ export class Keycard {
     return {
       valid: true,
       rateLimited,
-      remaining: Math.max(0, limits - keyCount),
+      remaining: Math.max(0, limit - keyCount),
       reset,
       limit
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ export class Keycard {
     return {
       valid: true,
       rateLimited,
-      remaining: rateLimited ? 0 : limits.monthly - keyCount,
+      remaining: Math.max(0, limits - keyCount),
       reset,
       limit
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,7 @@ export class Keycard {
       valid: true,
       rateLimited,
       remaining: rateLimited ? 0 : limits.monthly - keyCount,
-      reset: reset,
+      reset,
       limit
     };
   }

--- a/test/keycard.test.ts
+++ b/test/keycard.test.ts
@@ -3,12 +3,13 @@ import { Keycard } from '../src';
 
 describe('Test keyCard if no secret is passed', () => {
   let keycard: any = undefined;
-  it('should create a new instance of Keycard', () => {
+  it('should create a new instance of Keycard', async () => {
     keycard = new Keycard({
       app: 'snapshot-hub',
       secret: '',
       URL: 'http://localhost:3007'
     });
+    await new Promise(resolve => setTimeout(resolve, 1000));
     expect(keycard).toBeInstanceOf(Keycard);
   });
 
@@ -26,12 +27,13 @@ describe('Test keyCard if no secret is passed', () => {
 
 describe('Test keyCard if secret is passed', () => {
   let keycard: any = undefined;
-  it('should create a new instance of Keycard', () => {
+  it('should create a new instance of Keycard', async () => {
     keycard = new Keycard({
       app: 'snapshot-hub',
       secret: 'test',
       URL: 'http://localhost:3007'
     });
+    await new Promise(resolve => setTimeout(resolve, 1000));
     expect(keycard).toBeInstanceOf(Keycard);
   });
 
@@ -39,7 +41,14 @@ describe('Test keyCard if secret is passed', () => {
     await keycard.getKeys();
     expect(keycard.keys).toMatchObject({
       active: ['1234', '12345'],
-      restricted_monthly: ['12345']
+      restricted_monthly: ['12345'],
+      monthly_counts: {
+        '1234': 10,
+        '12345': 1000
+      },
+      limits: {
+        monthly: 1000
+      }
     });
   });
 

--- a/test/keycard.ts
+++ b/test/keycard.ts
@@ -11,5 +11,5 @@ import { sleep } from '../src/utils';
   await sleep(1000);
   console.log('Configured:', keycard.configured);
   console.log('Keys:', await keycard.getKeys());
-  console.log('logReq:', keycard.logReq('ABC'));
+  console.log('logReq:', keycard.logReq('123456789'));
 })();

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -4,7 +4,17 @@ import { rest } from 'msw';
 
 const result = {
   result: {
-    'snapshot-hub': { active: ['1234', '12345'], restricted_monthly: ['12345'] }
+    'snapshot-hub': {
+      active: ['1234', '12345'],
+      monthly_counts: {
+        '1234': 10,
+        '12345': 1000
+      },
+      restricted_monthly: ['12345'],
+      limits: {
+        monthly: 1000
+      }
+    }
   }
 };
 


### PR DESCRIPTION
Depends on https://github.com/snapshot-labs/keycard/pull/25/

## What's changing:
- Instead of using active keys and restricted keys, now we use counts and limits returned by the API and restrict the requests 
- If requests are coming from our own apps (snapshot-hub or sidekick) we need to pass secret in the header, and if the header is same as secret - we give unlimited access
- New values like `reset` and `limits` to return in response headers

How to test:
- Spin up keycard-api instance
- run `ts-node test/keycard.ts` 
- Looks at keys stored - we will use these values in our apps (hub/score api)
- Feel free to modify this file to test different scenarios 