### PR TITLE
feat: add keepAlive to connections

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:local": "ts-node test/keycard.ts"
   },
   "dependencies": {
-    "cross-fetch": "^3.1.5"
+    "node-fetch": "^2.7.0"
   },
   "eslintConfig": {
     "extends": "@snapshot-labs"

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,7 @@ export class Keycard {
       }),
       // @ts-ignore
       agent: function (parsedURL) {
+        return parsedURL.protocol === 'http:' ? httpAgent : httpsAgent;
       }
     });
     return result.json();

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,6 +127,7 @@ export class Keycard {
         method,
         params: { app, ...params }
       }),
+      timeout: 5e3,
       agent: this.agent
     });
     return result.json();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 import fetch from 'cross-fetch';
+import http from 'node:http';
+import https from 'node:https';
 import { sleep } from './utils';
 
 const API_URL = 'https://locahost:3007';
@@ -18,6 +20,9 @@ type AppKeys = {
   limits: Record<string, number>;
   reset: number;
 };
+
+const httpAgent = new http.Agent({ keepAlive: true });
+const httpsAgent = new https.Agent({ keepAlive: true });
 
 export class Keycard {
   app: string;
@@ -116,7 +121,10 @@ export class Keycard {
         jsonrpc: '2.0',
         method,
         params: { app, ...params }
-      })
+      }),
+      // @ts-ignore
+      agent: function (parsedURL) {
+      }
     });
     return result.json();
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -810,13 +810,6 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-fetch@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
-  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
-  dependencies:
-    node-fetch "2.6.7"
-
 cross-spawn@^7.0.0, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -1666,17 +1659,17 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-node-fetch@2.6.7:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
-  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
-  dependencies:
-    whatwg-url "^5.0.0"
-
 node-fetch@^2.6.7:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.9.tgz#7c7f744b5cc6eb5fd404e0c7a9fec630a55657e6"
   integrity sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
 


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Keycard API is being hit multiple times per seconds. All connections from services (score-api, hub) are using keycard.js, which is creating a new TCP connections per request.

Number of TCP connections per server is a limited resources, and creating a new one is creating overhead (DNS resolution, etc ...)

## 💊 Fixes / Solution

Fix https://github.com/snapshot-labs/keycard/issues/32
Fix [SNAPSHOT-HUB-9](https://snapshot-labs.sentry.io/issues/4377985087/?referrer=github_integration)

We should reuse the TCP connections whenever possible.

This will allow:
- faster connections (avoiding DNS overhead, etc ...)
- decrease number of concurrent TCP connections (reusing connections)

## 🚧 Changes

- Add 'agent' options to `fetch`, available only for node-fetch. Will not work on browser, but not our main use-case.

## 🛠️ Tests

- Use keycard from some other services (score-api)
- Analyze the http requests
- It should have the `keep-alive` header

## Notes

This is a test run, to confirm that this fix will resolve all connection issues, in particular all 504 errors. Once confirmed, it'll be added to all js libraries, such as pineapple.js, etc ...