### PR TITLE
feat: Handle new limits

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/keycard",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ type KeycardParams = {
 };
 
 type AppKeys = {
-  monthly_counts: Record<string, number>;
+  active_keys_counts: Record<string, { level: string; month: number }>;
   limits: Record<string, number>;
   reset: number;
 };
@@ -25,7 +25,7 @@ export class Keycard {
   configured = false;
   private secret: string | undefined;
   private keys: AppKeys = {
-    monthly_counts: {},
+    active_keys_counts: {},
     limits: {},
     reset: 0
   };
@@ -79,25 +79,25 @@ export class Keycard {
   } {
     if (!key) return { valid: false };
 
-    const { monthly_counts: activeKeys, limits, reset } = this.keys;
+    const { active_keys_counts: activeKeys, limits, reset } = this.keys;
     const { secret } = this;
-    const limit = limits.monthly;
+    const keyData = activeKeys[key];
 
     // Unlimited requests to snapshot APIs (example: if hub is sending requests to hub itself or to score-api)
     const unlimitedRequests = key === secret;
 
     // If key is not in active keys, it's not valid.
-    if (!unlimitedRequests && activeKeys[key] === undefined) return { valid: false };
+    if (!unlimitedRequests && keyData === undefined) return { valid: false };
 
-    activeKeys[key]++;
-    let keyCount = activeKeys[key];
+    keyData.month++;
+    let keyCount = keyData.month;
 
     if (unlimitedRequests) keyCount = 0;
     // Increase the total count for this key, but don't wait for it to finish.
     if (!unlimitedRequests) this.callAPI('log_req', { key }).catch(console.error);
 
+    const limit = limits[`${keyData.level}_monthly`];
     const rateLimited = keyCount > limit;
-
     return {
       valid: true,
       rateLimited,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,8 +13,8 @@ type KeycardParams = {
 };
 
 type AppKeys = {
-  key_counts: Record<string, { level: string; month: number }>;
-  limits: Record<string, number>;
+  key_counts: Record<string, { tier: string; month: number }>;
+  limits: Record<string, { monthly: number }>;
   reset: number;
 };
 
@@ -96,7 +96,7 @@ export class Keycard {
     // Increase the total count for this key, but don't wait for it to finish.
     if (!unlimitedRequests) this.callAPI('log_req', { key }).catch(console.error);
 
-    const limit = limits[`${keyData.level}_monthly`];
+    const limit = limits[keyData.tier].monthly;
     const rateLimited = keyCount > limit;
     return {
       valid: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ type KeycardParams = {
 };
 
 type AppKeys = {
-  active_keys_counts: Record<string, { level: string; month: number }>;
+  key_counts: Record<string, { level: string; month: number }>;
   limits: Record<string, number>;
   reset: number;
 };
@@ -25,7 +25,7 @@ export class Keycard {
   configured = false;
   private secret: string | undefined;
   private keys: AppKeys = {
-    active_keys_counts: {},
+    key_counts: {},
     limits: {},
     reset: 0
   };
@@ -79,7 +79,7 @@ export class Keycard {
   } {
     if (!key) return { valid: false };
 
-    const { active_keys_counts: activeKeys, limits, reset } = this.keys;
+    const { key_counts: activeKeys, limits, reset } = this.keys;
     const { secret } = this;
     const keyData = activeKeys[key];
 

--- a/test/keycard.test.ts
+++ b/test/keycard.test.ts
@@ -19,7 +19,7 @@ describe('Test keyCard if no secret is passed', () => {
 
   it('should return empty objects for keys', () => {
     expect(keycard.keys).toMatchObject({
-      active_keys_counts: {},
+      key_counts: {},
       limits: {},
       reset: 0
     });
@@ -40,9 +40,8 @@ describe('Test keyCard if secret is passed', () => {
 
   it('getKeys should add keys to keycard.keys', async () => {
     await keycard.getKeys();
-    console.log('Keys:', keycard.keys);
     expect(keycard.keys).toMatchObject({
-      active_keys_counts: {
+      key_counts: {
         '1234': {
           level: 'user',
           month: 10

--- a/test/keycard.test.ts
+++ b/test/keycard.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { Keycard } from '../src';
+import { exampleResponse } from './setup';
 
 describe('Test keyCard if no secret is passed', () => {
   let keycard: any = undefined;
@@ -40,21 +41,7 @@ describe('Test keyCard if secret is passed', () => {
 
   it('getKeys should add keys to keycard.keys', async () => {
     await keycard.getKeys();
-    expect(keycard.keys).toMatchObject({
-      key_counts: {
-        '1234': {
-          level: 'user',
-          month: 10
-        }
-      },
-      monthly_counts: {
-        '1234': 10,
-        '12345': 1000
-      },
-      limits: {
-        monthly: 1000
-      }
-    });
+    expect(keycard.keys).toMatchObject(exampleResponse.result['snapshot-hub']);
   });
 
   it('should return true for configured value', () => {

--- a/test/keycard.test.ts
+++ b/test/keycard.test.ts
@@ -19,8 +19,8 @@ describe('Test keyCard if no secret is passed', () => {
 
   it('should return empty objects for keys', () => {
     expect(keycard.keys).toMatchObject({
+      active_keys_counts: {},
       limits: {},
-      monthly_counts: {},
       reset: 0
     });
   });
@@ -40,7 +40,14 @@ describe('Test keyCard if secret is passed', () => {
 
   it('getKeys should add keys to keycard.keys', async () => {
     await keycard.getKeys();
+    console.log('Keys:', keycard.keys);
     expect(keycard.keys).toMatchObject({
+      active_keys_counts: {
+        '1234': {
+          level: 'user',
+          month: 10
+        }
+      },
       monthly_counts: {
         '1234': 10,
         '12345': 1000

--- a/test/keycard.ts
+++ b/test/keycard.ts
@@ -1,3 +1,5 @@
+// Usage: ts-node test/keycard.ts
+
 import { Keycard } from '../src';
 import { sleep } from '../src/utils';
 

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -5,12 +5,24 @@ import { rest } from 'msw';
 const result = {
   result: {
     'snapshot-hub': {
+      active_keys_counts: {
+        '1234': {
+          level: 'user',
+          month: 10
+        },
+        '12345': {
+          level: 'user',
+          month: 1000
+        }
+      },
       monthly_counts: {
         '1234': 10,
         '12345': 1000
       },
       limits: {
-        monthly: 1000
+        monthly: 1000,
+        user_monthly: 1000,
+        integrator_monthly: 1000
       }
     }
   }

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -5,7 +5,7 @@ import { rest } from 'msw';
 const result = {
   result: {
     'snapshot-hub': {
-      active_keys_counts: {
+      key_counts: {
         '1234': {
           level: 'user',
           month: 10

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -2,27 +2,26 @@ import { afterAll, afterEach, beforeAll } from 'vitest';
 import { setupServer } from 'msw/node';
 import { rest } from 'msw';
 
-const result = {
+export const exampleResponse = {
   result: {
     'snapshot-hub': {
       key_counts: {
         '1234': {
-          level: 'user',
+          tier: 0,
           month: 10
         },
         '12345': {
-          level: 'user',
-          month: 1000
+          tier: 1,
+          month: 2000
         }
       },
-      monthly_counts: {
-        '1234': 10,
-        '12345': 1000
-      },
       limits: {
-        monthly: 1000,
-        user_monthly: 1000,
-        integrator_monthly: 1000
+        '0': {
+          monthly: 1000
+        },
+        '1': {
+          monthly: 2000
+        }
       }
     }
   }
@@ -32,7 +31,7 @@ export const restHandlers = [
   rest.post('http://localhost:3007', (req: any, res: any, ctx) => {
     console.log('req', req.body);
     if (req.body?.method === 'get_keys') {
-      return res(ctx.status(200), ctx.json(result));
+      return res(ctx.status(200), ctx.json(exampleResponse));
     }
     return res(
       ctx.status(200),


### PR DESCRIPTION
Merge only after https://github.com/snapshot-labs/keycard/pull/46

Summary of changes:
- handle `key_counts` from API, instead of `monthly_counts`
- Fix tests

### How to test:
- Make sure you are running the keycard API
- Run `ts-node test/keycard.ts` 
- Update limits and add more `logReq` calls to test